### PR TITLE
Hotfix: Tabing broke the ICLogin

### DIFF
--- a/packages/IMAPClient-UI.package/ICLoginDialog.class/instance/changeInputField..st
+++ b/packages/IMAPClient-UI.package/ICLoginDialog.class/instance/changeInputField..st
@@ -13,11 +13,12 @@ changeInputField: currentIndex
 		
 		"get text of next input field"
 		text := self perform: (correctSubmorph getTextSelector).
-		(text size > 0)
-		ifTrue: [
-			"select text of morph"
-			correctSubmorph textMorph editor selectInterval: (1 to: (text size))	
-		].
-	
+		text ifNotNil:[
+			text size > 0
+				ifTrue: [
+					"select text of morph"
+					correctSubmorph textMorph editor selectInterval: (1 to: (text size))	
+				]
+			].
 		correctSubmorph grabKeyboard.
 	]

--- a/packages/IMAPClient-UI.package/ICLoginDialog.class/methodProperties.json
+++ b/packages/IMAPClient-UI.package/ICLoginDialog.class/methodProperties.json
@@ -7,7 +7,7 @@
 	"instance" : {
 		"applyCredentials" : "DH 5/12/2018 09:09",
 		"buildWith:" : "DH 5/30/2018 00:23",
-		"changeInputField:" : "DH 5/30/2018 00:32",
+		"changeInputField:" : "DH 5/30/2018 14:16",
 		"checkBoxColor" : "ms 7/13/2016 17:34",
 		"checkIfLastCharacterIsTab:" : "DH 5/23/2018 00:32",
 		"credentials" : "DH 5/5/2018 18:45",


### PR DESCRIPTION
Just needed to check whether the content of the next field is nil.