### PR TITLE
Initialize login dialog with prefilled settings

### DIFF
--- a/packages/IMAPClient-UI.package/ICLoginDialog.class/instance/initialize.st
+++ b/packages/IMAPClient-UI.package/ICLoginDialog.class/instance/initialize.st
@@ -2,7 +2,8 @@ initialization
 initialize
 
 	super initialize.
-	self ssl: false.
+	self ssl: true.
+	self serverPort: (Text fromString: '993').
 	self updateMode: false.
 	self symbolArray: OrderedCollection new. 
 	self symbolArray add: #name.

--- a/packages/IMAPClient-UI.package/ICLoginDialog.class/methodProperties.json
+++ b/packages/IMAPClient-UI.package/ICLoginDialog.class/methodProperties.json
@@ -30,7 +30,7 @@
 		"guiElementYOffset" : "ms 7/12/2016 10:45",
 		"guiElementYOffsetOf:" : "C.G. 7/25/2018 14:23",
 		"guiElementYSpacing" : "ms 6/14/2016 10:05",
-		"initialize" : "C.G. 7/25/2018 14:23",
+		"initialize" : "ok 6/25/2019 01:30",
 		"inputCollection" : "C.G. 7/25/2018 14:23",
 		"inputCollection:" : "pm 6/9/2019 17:12",
 		"keyEvent:" : "DH 7/25/2018 00:08",


### PR DESCRIPTION
This is a draft to fix #223. We could add a way to store defaults in a special class method, what do you think?

However, I think the prefilled port value goes terrible with the field labels:

![Screenshot 2019-06-25 at 01 25 33](https://user-images.githubusercontent.com/1622854/60058595-445cf580-96e9-11e9-874d-b37257a4b355.png)