### PR TITLE
Made Deployment modular

### DIFF
--- a/packages/IMAPClient-Tests.package/ICDeployment.class/README.md
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/README.md
@@ -1,1 +1,2 @@
 This class supports automatic releases via travis. It is not used for testing but enables automatic sar bulding.
+As the build takes longer than 5 seconds a custom timeout is set in setUp. This enforces fast builds as well

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/class/createMCZfor.in..st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/class/createMCZfor.in..st
@@ -1,0 +1,10 @@
+release building
+createMCZfor: aPackageName in: aZIP
+
+| mczStream workingCopy version |
+
+mczStream := RWBinaryOrTextStream on: (String new: 10000).
+workingCopy := MCWorkingCopy forPackage: (MCPackage new name: aPackageName).
+version := workingCopy newVersionWithName: aPackageName message: ('new ', aPackageName , ' release').
+version fileOutOn: mczStream.
+(aZIP addString: mczStream contents as: (aPackageName, '.mcz')) desiredCompressionLevel: 0.

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/class/packagesToDeploy.st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/class/packagesToDeploy.st
@@ -1,0 +1,4 @@
+release building
+packagesToDeploy
+
+	^ {'IMAPClient-Core'. 'IMAPClient-UI'. 'IMAPClient-Protocol'}

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/class/preambleString.st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/class/preambleString.st
@@ -1,0 +1,7 @@
+release building
+preambleString
+	
+	^ ((self packagesToDeploy collect: [:packageName | 
+			'self fileInMonticelloZipVersionNamed: ''', packageName, '.mcz''.']) joinSeparatedBy: String cr),
+		String cr,
+		'ICFolderDialog install.'.

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/class/releaseName.st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/class/releaseName.st
@@ -1,0 +1,4 @@
+release building
+releaseName
+
+	^ 'IMAPClient-Release'

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/instance/setUp.st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/instance/setUp.st
@@ -1,0 +1,4 @@
+deployment
+setUp
+
+self timeout: 60.

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/instance/testDeployment.st
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/instance/testDeployment.st
@@ -1,26 +1,11 @@
 deployment
 testDeployment
 
-|zip mczStream workingCopy version |
+| zip |
 
 zip := ZipArchive new.
 
-mczStream := RWBinaryOrTextStream on: (String new: 10000).
-workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'IMAPClient-Core').
-version := workingCopy newVersionWithName: 'IMAPClient-Core' message: 'new core release'.
-version fileOutOn: mczStream.
-(zip addString: mczStream contents as: 'IMAPClient-Core.mcz') desiredCompressionLevel: 0.
+self class packagesToDeploy do: [:package | self class createMCZfor: package in: zip].
+zip addString: self class preambleString as: 'install/preamble'.
 
-mczStream := RWBinaryOrTextStream on: (String new: 10000).
-workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'IMAPClient-UI').
-version := workingCopy newVersionWithName: 'IMAPClient-UI' message: 'new ui release'.
-version fileOutOn: mczStream.
-(zip addString: mczStream contents as: 'IMAPClient-UI.mcz') desiredCompressionLevel: 0.
-
-zip addString: 'self fileInMonticelloZipVersionNamed:
-    ''IMAPClient-Core.mcz''.
-self fileInMonticelloZipVersionNamed:
-    ''IMAPClient-UI.mcz''.
-ICFolderDialog install.' as: 'install/preamble'.
-
-zip writeToFileNamed: 'newRelease.sar'.
+zip writeToFileNamed: (self class releaseName, '.sar').

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/methodProperties.json
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/methodProperties.json
@@ -1,5 +1,9 @@
 {
 	"class" : {
-		 },
+		"createMCZfor:in:" : "tg 7/26/2019 10:35",
+		"packagesToDeploy" : "tg 7/25/2019 21:24",
+		"preambleString" : "tg 7/26/2019 10:16",
+		"releaseName" : "tg 7/26/2019 10:31" },
 	"instance" : {
-		"testDeployment" : "tg 6/5/2019 16:17" } }
+		"setUp" : "tg 7/26/2019 10:07",
+		"testDeployment" : "tg 7/26/2019 10:07" } }

--- a/packages/IMAPClient-Tests.package/ICDeployment.class/properties.json
+++ b/packages/IMAPClient-Tests.package/ICDeployment.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "tg 7/9/2019 14:46",
+	"commentStamp" : "tg 7/26/2019 10:33",
 	"instvars" : [
 		 ],
 	"name" : "ICDeployment",


### PR DESCRIPTION
I split the zip building method blob into parameterized methods.
The packaged that will be deployed are now stored in a separate constant method, which we can add new packages to if needed.