### PR TITLE
Fixed whitespace assumption

### DIFF
--- a/packages/IMAPClient-Protocol.package/ICParser.class/class/populate.withHeadersFrom..st
+++ b/packages/IMAPClient-Protocol.package/ICParser.class/class/populate.withHeadersFrom..st
@@ -6,7 +6,10 @@ populate: anEmail withHeadersFrom: aHeaderChunk
 	headerField := (aHeaderChunk first subStrings: ' ') first.
 	(headerField includesSubString: ':') ifTrue: [headerField := headerField allButLast].
 	
-	aHeaderContentChunk := (aHeaderChunk joinSeparatedBy: ' ') copyReplaceFrom: 1 to: (aHeaderChunk first indexOf: $:) + 1 with: String empty.
+	aHeaderContentChunk := ((aHeaderChunk joinSeparatedBy: ' ')
+		copyReplaceFrom: 1 
+		to: (aHeaderChunk first indexOf: $:) 
+		with: String empty) withoutLeadingBlanks.
 	
 	method := 	(self parseMethods at: headerField ifAbsent: nil).
 	method ifNil: [Transcript show: 'WARNING: No method for parsing Header field:', headerField; cr]

--- a/packages/IMAPClient-Protocol.package/ICParser.class/methodProperties.json
+++ b/packages/IMAPClient-Protocol.package/ICParser.class/methodProperties.json
@@ -16,7 +16,7 @@
 		"populate:withContentType:" : "pm 7/25/2019 17:37",
 		"populate:withDate:" : "pm 7/25/2019 17:37",
 		"populate:withFlags:" : "pm 7/25/2019 17:37",
-		"populate:withHeadersFrom:" : "pm 7/25/2019 17:34",
+		"populate:withHeadersFrom:" : "tg 7/26/2019 11:06",
 		"populate:withReceiver:" : "pm 7/25/2019 17:37",
 		"populate:withSender:" : "pm 7/25/2019 17:38",
 		"populate:withSubject:" : "pm 7/25/2019 17:38",


### PR DESCRIPTION
This fixes #279 

Still removes everything before the colon including the colon itself.
But then all leading whitespace is removed