### PR TITLE
Refactor/229 inconform string note

### DIFF
--- a/packages/IMAPClient-Protocol.package/ICParser.class/class/populate.withHeadersFrom..st
+++ b/packages/IMAPClient-Protocol.package/ICParser.class/class/populate.withHeadersFrom..st
@@ -6,7 +6,10 @@ populate: anEmail withHeadersFrom: aHeaderChunk
 	headerField := (aHeaderChunk first subStrings: ' ') first.
 	(headerField includesSubString: ':') ifTrue: [headerField := headerField allButLast].
 	
-	aHeaderContentChunk := (aHeaderChunk joinSeparatedBy: ' ') copyReplaceFrom: 1 to: (aHeaderChunk first indexOf: $:) + 1 with: String empty.
+	aHeaderContentChunk := ((aHeaderChunk joinSeparatedBy: ' ')
+		copyReplaceFrom: 1 
+		to: (aHeaderChunk first indexOf: $:) 
+		with: String empty) withoutLeadingBlanks.
 	
 	method := 	(self parseMethods at: headerField ifAbsent: nil).
 	method ifNil: [Transcript show: 'WARNING: No method for parsing Header field:', headerField; cr]

--- a/packages/IMAPClient-Protocol.package/ICParser.class/methodProperties.json
+++ b/packages/IMAPClient-Protocol.package/ICParser.class/methodProperties.json
@@ -16,7 +16,7 @@
 		"populate:withContentType:" : "pm 7/25/2019 17:37",
 		"populate:withDate:" : "pm 7/25/2019 17:37",
 		"populate:withFlags:" : "pm 7/25/2019 17:37",
-		"populate:withHeadersFrom:" : "pm 7/25/2019 17:34",
+		"populate:withHeadersFrom:" : "tg 7/26/2019 11:06",
 		"populate:withReceiver:" : "pm 7/25/2019 17:37",
 		"populate:withSender:" : "pm 7/25/2019 17:38",
 		"populate:withSubject:" : "pm 7/25/2019 17:38",

--- a/packages/IMAPClient-UI.package/ICPasswordDialog.class/instance/login.st
+++ b/packages/IMAPClient-UI.package/ICPasswordDialog.class/instance/login.st
@@ -9,7 +9,9 @@ login
  
 	self data at: 'password' put: (self password asString).
 	
-	[accountInfo := ICAccountInfo newWith: data.] on: Error do: [:e | self inform: e messageText. ^ self].
+	[accountInfo := ICAccountInfo newWith: data.]
+		on: Error
+		do: [:e | self inform: e asString. ^ self].
 	
 	((ICEndPoint new) testAccountWith: accountInfo)
 		ifTrue: [

--- a/packages/IMAPClient-UI.package/ICPasswordDialog.class/instance/login.st
+++ b/packages/IMAPClient-UI.package/ICPasswordDialog.class/instance/login.st
@@ -1,14 +1,17 @@
 login
 login
-
+	
+	| accountInfo |
 	(self password = nil)
 		ifTrue: [
-			UserDialogBoxMorph inform: 'Please put in a password' title: ''.
+			self inform: 'Please put in a password'.
 			^ self].
  
 	self data at: 'password' put: (self password asString).
 	
-	((ICEndPoint new) testAccountWith: (ICAccountInfo newWith: data))
+	[accountInfo := ICAccountInfo newWith: data.] on: Error do: [:e | self inform: e messageText. ^ self].
+	
+	((ICEndPoint new) testAccountWith: accountInfo)
 		ifTrue: [
 			self folderDialogInstance addPasswordToCollection: (self data).
 			self window abandon]

--- a/packages/IMAPClient-UI.package/ICPasswordDialog.class/methodProperties.json
+++ b/packages/IMAPClient-UI.package/ICPasswordDialog.class/methodProperties.json
@@ -9,7 +9,7 @@
 		"data:" : "pm 6/9/2019 17:14",
 		"folderDialogInstance" : "C.G. 7/25/2018 14:25",
 		"folderDialogInstance:" : "pm 6/9/2019 17:14",
-		"login" : "tg 7/26/2019 11:30",
+		"login" : "tg 7/26/2019 11:45",
 		"loginWithPassword:" : "fr 6/13/2019 14:39",
 		"password" : "C.G. 7/25/2018 14:25",
 		"password:" : "fr 6/13/2019 14:44",

--- a/packages/IMAPClient-UI.package/ICPasswordDialog.class/methodProperties.json
+++ b/packages/IMAPClient-UI.package/ICPasswordDialog.class/methodProperties.json
@@ -9,7 +9,7 @@
 		"data:" : "pm 6/9/2019 17:14",
 		"folderDialogInstance" : "C.G. 7/25/2018 14:25",
 		"folderDialogInstance:" : "pm 6/9/2019 17:14",
-		"login" : "tg 7/11/2019 10:04",
+		"login" : "tg 7/26/2019 11:30",
 		"loginWithPassword:" : "fr 6/13/2019 14:39",
 		"password" : "C.G. 7/25/2018 14:25",
 		"password:" : "fr 6/13/2019 14:44",


### PR DESCRIPTION
This fixes #229 

I added a catch for the Error. The error still throws in `ICAccountInfo` but is now caught in UI and transformed to a UI Note.
