### PR TITLE
Remove warning at 'Move to trash'

### DIFF
--- a/packages/IMAPClient-UI.package/ICFolderDialog.class/instance/deleteEmail.st
+++ b/packages/IMAPClient-UI.package/ICFolderDialog.class/instance/deleteEmail.st
@@ -1,9 +1,6 @@
 email selection
 deleteEmail
 	
-	self error: 'WARNING: This empties your trash and makes the selected mail unrecoverable.
-		 Only proceed if you are confident you want this'.
-	
 	self selectedEmail retrieveFlags.
 	
 	(self selectedEmail deleted)

--- a/packages/IMAPClient-UI.package/ICFolderDialog.class/methodProperties.json
+++ b/packages/IMAPClient-UI.package/ICFolderDialog.class/methodProperties.json
@@ -24,7 +24,7 @@
 		"currentRemoteVatId" : "dl 6/23/2017 12:30",
 		"defaultBackgroundColor" : "C.G. 7/25/2018 14:16",
 		"deleteAccountButton:" : "tg 7/25/2019 20:28",
-		"deleteEmail" : "tg 7/26/2019 14:37",
+		"deleteEmail" : "ok 7/26/2019 15:22",
 		"dialogTitle" : "ms 6/26/2016 13:50",
 		"editAccount:with:" : "tg 7/25/2019 11:46",
 		"editAccountButton:" : "tg 7/11/2019 10:00",


### PR DESCRIPTION
This fixes #284, as the 'not-moving' was not a problem.
Therefore I removed the warning.