### PR TITLE
Add widgets as dependency

### DIFF
--- a/packages/BaselineOfIMAPClient.package/BaselineOfIMAPClient.class/instance/baseline..st
+++ b/packages/BaselineOfIMAPClient.package/BaselineOfIMAPClient.class/instance/baseline..st
@@ -6,6 +6,7 @@ baseline: spec
         do: [ 
             spec
 		    package: 'JSON' with: [ spec file: 'JSON-ul.35'; repository: 'http://www.squeaksource.com/JSON' ];
+		    baseline: 'Widgets' with: [ spec repository: 'github://hpi-swa/widgets:master/repository'];
                 package: 'IMAPClient-Core';
 		    package: 'IMAPClient-UI';
 			package: 'IMAPClient-Protocol';
@@ -13,4 +14,4 @@ baseline: spec
             spec
                 group: 'default' with: #('IMAPClient-UI' 'IMAPClient-Core' 'IMAPClient-Protocol');
                 group: 'Tests' with: #('IMAPClient-Tests');
-		    group: 'libaries' with: #('JSON')]
+		    group: 'libaries' with: #('JSON' 'Widgets')]


### PR DESCRIPTION
The SWT image ships with widgets preinstalled, but it's missing in stock Squeak images. Unfortunately, this was not caught by CI, probably because the UI is not tested (yet).